### PR TITLE
JSON was invalid

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "puppet-galera",
   "version": "0.0.2",
-  "author": "Ryan O\'Hara",
+  "author": "Ryan O'Hara",
   "summary": "Install/Configure MariaDB with galera",
   "license": "Apache 2.0",
   "source": "git://github.com/redhat-openstack/puppet-galera.git",
@@ -30,7 +30,7 @@
         "6",
         "7"
       ]
-    },
+    }
   ],
   "requirements": [
     {


### PR DESCRIPTION
Created an warning/error message when applying Puppet

$ cat metadata.json | json_verify
lexical error: inside a string, '\' occurs before a character which it
may not.
                                        {   "name": "puppet-galera",
                     (right here) ------^
