### PR TITLE
Fix to support mysql module > 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,19 @@ It depends on the mysql module from puppetlabs as well as xinetd.
   starts mysqld service:
 
     class { 'galera::server':
-      config_hash => {
-        bind_address   => '0.0.0.0',
-        default_engine => 'InnoDB',
-        root_password  => 'root_pass',
+      mysql_server_hash => {
+        override_options        => {
+          'mysqld' => {
+            'bind-address'           => '0.0.0.0',
+            'default-storage-engine' => 'InnoDB',
+          }
+        },
+        package_name            => 'mariadb-galera-cluster',
+        service_enabled         => true,
+        service_manage          => true,
+        root_password           => 'ChangeMe',
+        restart                 => false,
+        remove_default_accounts => true,
       },
       wsrep_cluster_name => 'galera_cluster',
       wsrep_sst_method   => 'rsync'

--- a/manifests/monitor.pp
+++ b/manifests/monitor.pp
@@ -78,13 +78,15 @@ class galera::monitor (
     log_on_success_operator => '=',
     log_on_failure          => 'HOST',
     log_on_failure_operator => '=',
+    # the monitor script is part of the mysql-server package
+    subscribe               => Package['mysql-server'],
   }
 
   if $create_mysql_user {
     mysql_user { "${mysql_username}@${mysql_host}":
       ensure        => present,
       password_hash => mysql_password($mysql_password),
-      require       => [File['/root/.my.cnf'],Service['galera']],
+      require       => [File['/root/.my.cnf'],Service['mysqld']],
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -44,8 +44,8 @@
   ],
   "description": "Install/Configure MariaDB with Galera",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 2.4.0"},
-    {"name":"puppetlabs/mysql","version_requirement":">= 2.3.1"},
-    {"name":"puppetlabs/xinetd","version_requirement":">= 1.2.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 5.0.0"},
+    {"name":"puppetlabs/mysql","version_requirement":">= 3.2.0 < 4.0.0"},
+    {"name":"puppetlabs/xinetd","version_requirement":">= 1.2.0 < 2.0.0"}
   ]
 }

--- a/spec/classes/galera_server_spec.rb
+++ b/spec/classes/galera_server_spec.rb
@@ -9,11 +9,6 @@ describe 'galera::server', :type => :class do
   let :params do
     {
       :bootstrap             => false,
-      :debug                 => false,
-      :service_name          => 'mariadb',
-      :service_enable        => true,
-      :service_ensure        => 'running',
-      :manage_service        => false,
       :wsrep_bind_address    => '0.0.0.0',
       :wsrep_node_address    => 'undef',
       :wsrep_provider        => '/usr/lib64/galera/libgalera_smm.so',
@@ -25,6 +20,7 @@ describe 'galera::server', :type => :class do
       :wsrep_ssl             => false,
       :wsrep_ssl_key         => 'undef',
       :wsrep_ssl_cert        => 'undef',
+      :debug                 => false,
     }
   end
 
@@ -36,25 +32,8 @@ describe 'galera::server', :type => :class do
       'mode'   => '0644',
       'owner'  => 'root',
       'group'  => 'root',
-      'notify' => 'Service[mariadb]'
+      'before' => 'Service[mysqld]'
       )
     }
-  end
-
-  context 'with manage_service to false' do
-    it "Doesn't configure galera service" do
-      should_not contain_service('galera')
-    end
-  end
-
-  context 'with manage_service to true' do
-    let(:params) { {:manage_service => true} }
-    it "Configures galera service" do
-      should contain_service('galera').with(
-        'ensure' => 'running',
-        'name'   => 'mariadb',
-        'enable' => 'true',
-      )
-    end
   end
 end

--- a/templates/wsrep.cnf.erb
+++ b/templates/wsrep.cnf.erb
@@ -46,6 +46,15 @@ wsrep_provider_options="<%= @wsrep_provider_options.join '; ' %>"
 # Logical cluster name. Should be the same for all nodes.
 wsrep_cluster_name="<%= @wsrep_cluster_name %>"
 
+# Group communication system handle
+<% if @wsrep_cluster_members.empty? -%>
+wsrep_cluster_address="dummy://"
+<% elsif @bootstrap -%>
+wsrep_cluster_address="gcomm://"
+<% else -%>
+wsrep_cluster_address="gcomm://<%= @wsrep_cluster_members.join ',' %>"
+<% end -%>
+
 # Human-readable node name (non-unique). Hostname by default.
 #wsrep_node_name=
 


### PR DESCRIPTION
Change the possible options and names to be back in sync with the puppetlabs-mysql module in versions > 3.0.0