### PR TITLE
Deprecate mysql::server resource creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,9 @@ It depends on the mysql module from puppetlabs as well as xinetd.
 
 ### galera::server
 
-  Used to deploy and manage a MariaDB Galera server cluster. Installs
-  mariadb-galera-server and galera packages, configures galera.cnf and
-  starts mysqld service:
+  Used to configure a MariaDB Galera server cluster.
 
     class { 'galera::server':
-      config_hash => {
-        bind_address   => '0.0.0.0',
-        default_engine => 'InnoDB',
-        root_password  => 'root_pass',
-      },
       wsrep_cluster_name => 'galera_cluster',
       wsrep_sst_method   => 'rsync'
       wsrep_sst_username => 'ChangeMe',

--- a/manifests/monitor.pp
+++ b/manifests/monitor.pp
@@ -84,7 +84,7 @@ class galera::monitor (
     mysql_user { "${mysql_username}@${mysql_host}":
       ensure        => present,
       password_hash => mysql_password($mysql_password),
-      require       => [File['/root/.my.cnf'],Service['galera']],
+      require       => [File['/root/.my.cnf'],Service['mysqld']],
     }
   }
 }

--- a/templates/wsrep.cnf.erb
+++ b/templates/wsrep.cnf.erb
@@ -28,11 +28,6 @@ innodb_locks_unsafe_for_binlog=1
 #### query_cache_size=0 now in server.cnf
 query_cache_type=0
 
-# Override bind-address
-# In some systems bind-address defaults to 127.0.0.1, and with mysqldump SST
-# it will have (most likely) disastrous consequences on donor node
-bind-address=<%= @wsrep_bind_address %>
-
 ##
 ## WSREP options
 ##
@@ -41,10 +36,14 @@ bind-address=<%= @wsrep_bind_address %>
 wsrep_provider=<%= @wsrep_provider %>
 
 # Provider specific configuration options
-wsrep_provider_options="<%= @wsrep_provider_options.join '; ' %>"
+wsrep_provider_options="<%= @wsrep_provider_options.join '; ' %>;gmcast.listen_addr=tcp://<%= @wsrep_bind_address %>:4567"
 
 # Logical cluster name. Should be the same for all nodes.
 wsrep_cluster_name="<%= @wsrep_cluster_name %>"
+
+<% if @bootstrap -%>
+wsrep_cluster_address="gcomm://<%= @wsrep_cluster_members.join ',' %>?pc.wait_prim=no"
+<% end -%>
 
 # Human-readable node name (non-unique). Hostname by default.
 #wsrep_node_name=


### PR DESCRIPTION
Class mysql::server should be called manually and bind host should
be specified for this class as create_resource causes dependancy
issues and bind_host override collides with mysql::server default
setting.