### PR TITLE
Fix wsrep_provider_options if SSL false 

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -73,11 +73,17 @@ class galera::server (
     ensure => $package_ensure,
   }
 
-  $wsrep_provider_options = wsrep_options({
-    'socket.ssl'      => $wsrep_ssl,
-    'socket.ssl_key'  => $wsrep_ssl_key,
-    'socket.ssl_cert' => $wsrep_ssl_cert,
-  })
+  if $wsrep_ssl {
+    $wsrep_provider_options = wsrep_options({
+      'socket.ssl'      => $wsrep_ssl,
+      'socket.ssl_key'  => $wsrep_ssl_key,
+      'socket.ssl_cert' => $wsrep_ssl_cert,
+    })
+  } else {
+    $wsrep_provider_options = wsrep_options({
+      'socket.ssl'      => $wsrep_ssl,
+    })
+  }
 
   $wsrep_debug = bool2num($debug)
 


### PR DESCRIPTION
Currently when wsrep_ssl is set to false but wsrep_ssl_cert and
wsrep_ssl_key are set and invalid configuration results.

gcomm+ssl will correctly disable SSL, but IST still tries to run
via SSL and will consequently fail.

Fixes: rhbz#1277539
